### PR TITLE
Remove the extra published statement from datset description

### DIFF
--- a/src/TemplateRenderer.php
+++ b/src/TemplateRenderer.php
@@ -123,8 +123,7 @@ class TemplateRenderer
             "description" => "Near real-time availability and rich ".
                 "descriptions relating to the ".
                 strtolower($dataFeedHumanisedList)." available from ".
-                $settings["organisationName"].", published using the ".
-                "OpenActive Modelling Specification 2.0.",
+                $settings["organisationName"],
             "keywords" => $keywords,
             "license" => "https://creativecommons.org/licenses/by/4.0/",
             "discussionUrl" => $settings["datasetDiscussionUrl"],


### PR DESCRIPTION
Same as in Ruby library: https://github.com/openactive/dataset-site-template-ruby/pull/7

Think this is all that's needed for the "Dataset site text issues" from https://3.basecamp.com/3209127/buckets/13476163/messages/2240405464
